### PR TITLE
Add fd_p{read, write} test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = "0.2.4"
 source = "git+https://github.com/sunfishcode/rust-errno?branch=wasi#7ef8e9f94a43d5a90b1307ab4ab010d13474a190"
 dependencies = [
  "errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -16,7 +16,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -26,12 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.58"
-source = "git+https://github.com/rust-lang/libc#5bbba03eb19c8a60efa2aa44a8cef118748c9811"
+version = "0.2.59"
+source = "git+https://github.com/rust-lang/libc#54b03c53fb8e70bcce87dc26d8795c995e41061f"
 
 [[package]]
 name = "libc"
-version = "0.2.58"
+version = "0.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -39,7 +39,7 @@ name = "misc-tests"
 version = "0.1.0"
 dependencies = [
  "errno 0.2.4 (git+https://github.com/sunfishcode/rust-errno?branch=wasi)",
- "libc 0.2.58 (git+https://github.com/rust-lang/libc)",
+ "libc 0.2.59 (git+https://github.com/rust-lang/libc)",
 ]
 
 [[package]]
@@ -65,8 +65,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum errno 0.2.4 (git+https://github.com/sunfishcode/rust-errno?branch=wasi)" = "<none>"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-"checksum libc 0.2.58 (git+https://github.com/rust-lang/libc)" = "<none>"
-"checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
+"checksum libc 0.2.59 (git+https://github.com/rust-lang/libc)" = "<none>"
+"checksum libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)" = "3262021842bf00fe07dbd6cf34ff25c99d7a7ebef8deea84db72be3ea3bb0aff"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/src/bin/file_pread_pwrite.rs
+++ b/src/bin/file_pread_pwrite.rs
@@ -1,0 +1,102 @@
+use libc;
+use misc_tests::open_scratch_directory;
+use misc_tests::utils::close_fd;
+use misc_tests::wasi::{wasi_fd_pread, wasi_fd_pwrite, wasi_path_open};
+use std::{env, process};
+
+fn test_file_pread_pwrite(dir_fd: libc::__wasi_fd_t) {
+    // Create a file in the scratch directory.
+    let mut file_fd = libc::__wasi_fd_t::max_value() - 1;
+    let mut status = wasi_path_open(
+        dir_fd,
+        0,
+        "file",
+        libc::__WASI_O_CREAT,
+        libc::__WASI_RIGHT_FD_READ | libc::__WASI_RIGHT_FD_WRITE,
+        0,
+        0,
+        &mut file_fd,
+    );
+    assert_eq!(status, libc::__WASI_ESUCCESS, "opening a file");
+    assert!(
+        file_fd > libc::STDERR_FILENO as libc::__wasi_fd_t,
+        "file descriptor range check",
+    );
+
+    let contents = &[0u8, 1, 2, 3];
+    let ciovec = libc::__wasi_ciovec_t {
+        buf: contents.as_ptr() as *const libc::c_void,
+        buf_len: contents.len(),
+    };
+    let mut nwritten = 0;
+    status = wasi_fd_pwrite(file_fd, &mut [ciovec], 0, &mut nwritten);
+    assert_eq!(status, libc::__WASI_ESUCCESS, "writing bytes at offset 0");
+    assert_eq!(nwritten, 4, "nwritten bytes check");
+
+    let contents = &mut [0u8; 4];
+    let iovec = libc::__wasi_iovec_t {
+        buf: contents.as_mut_ptr() as *mut libc::c_void,
+        buf_len: contents.len(),
+    };
+    let mut nread = 0;
+    status = wasi_fd_pread(file_fd, &[iovec], 0, &mut nread);
+    assert_eq!(status, libc::__WASI_ESUCCESS, "reading bytes at offset 0");
+    assert_eq!(nread, 4, "nread bytes check");
+    assert_eq!(contents, &[0u8, 1, 2, 3], "written bytes equal read bytes");
+
+    let contents = &mut [0u8; 4];
+    let iovec = libc::__wasi_iovec_t {
+        buf: contents.as_mut_ptr() as *mut libc::c_void,
+        buf_len: contents.len(),
+    };
+    let mut nread = 0;
+    status = wasi_fd_pread(file_fd, &[iovec], 2, &mut nread);
+    assert_eq!(status, libc::__WASI_ESUCCESS, "reading bytes at offset 2");
+    assert_eq!(nread, 2, "nread bytes check");
+    assert_eq!(contents, &[2u8, 3, 0, 0], "file cursor was overwritten");
+
+    let contents = &[1u8, 0];
+    let ciovec = libc::__wasi_ciovec_t {
+        buf: contents.as_ptr() as *const libc::c_void,
+        buf_len: contents.len(),
+    };
+    let mut nwritten = 0;
+    status = wasi_fd_pwrite(file_fd, &mut [ciovec], 2, &mut nwritten);
+    assert_eq!(status, libc::__WASI_ESUCCESS, "writing bytes at offset 2");
+    assert_eq!(nwritten, 2, "nwritten bytes check");
+
+    let contents = &mut [0u8; 4];
+    let iovec = libc::__wasi_iovec_t {
+        buf: contents.as_mut_ptr() as *mut libc::c_void,
+        buf_len: contents.len(),
+    };
+    let mut nread = 0;
+    status = wasi_fd_pread(file_fd, &[iovec], 0, &mut nread);
+    assert_eq!(status, libc::__WASI_ESUCCESS, "reading bytes at offset 0");
+    assert_eq!(nread, 4, "nread bytes check");
+    assert_eq!(contents, &[0u8, 1, 1, 0], "file cursor was overwritten");
+
+    close_fd(file_fd);
+}
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    test_file_pread_pwrite(dir_fd)
+}

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -172,3 +172,21 @@ pub fn wasi_fd_write(
 ) -> libc::__wasi_errno_t {
     unsafe { libc::__wasi_fd_write(fd, iovs.as_ptr(), iovs.len(), nwritten) }
 }
+
+pub fn wasi_fd_pread(
+    fd: libc::__wasi_fd_t,
+    iovs: &[libc::__wasi_iovec_t],
+    offset: libc::__wasi_filesize_t,
+    nread: &mut usize,
+) -> libc::__wasi_errno_t {
+    unsafe { libc::__wasi_fd_pread(fd, iovs.as_ptr(), iovs.len(), offset, nread) }
+}
+
+pub fn wasi_fd_pwrite(
+    fd: libc::__wasi_fd_t,
+    iovs: &mut [libc::__wasi_ciovec_t],
+    offset: libc::__wasi_filesize_t,
+    nwritten: &mut usize,
+) -> libc::__wasi_errno_t {
+    unsafe { libc::__wasi_fd_pwrite(fd, iovs.as_ptr(), iovs.len(), offset, nwritten) }
+}


### PR DESCRIPTION
Tests `fd_pread` and `fd_pwrite` hostcalls. There is one caveat here though: the test doesn't perform a full cleanup (i.e., it doesn't "unlink" the created "file"). This is due to the fact, on Windows, we're still missing the implementation of `path_unlink_file`, and I'd like to utilise this test already on all platforms, so I've decided to omit the clean-up. I guess we could add it later when we have the implementation of `path_unlink_file` on all platforms.