### PR TITLE
Add a test for fd_readdir

### DIFF
--- a/src/bin/fd_readdir.rs
+++ b/src/bin/fd_readdir.rs
@@ -1,0 +1,106 @@
+use libc;
+use misc_tests::open_scratch_directory;
+use misc_tests::wasi_wrappers::wasi_fd_readdir;
+use std::{cmp::min, env, mem, process, slice, str};
+
+const BUF_LEN: usize = 256;
+
+struct DirEntry {
+    dirent: libc::__wasi_dirent_t,
+    name: String,
+}
+
+// Manually reading the output from fd_readdir is tedious and repetitive,
+// so encapsulate it into an iterator
+struct ReadDir<'a> {
+    buf: &'a [u8],
+}
+
+impl<'a> ReadDir<'a> {
+    fn from_slice(buf: &'a [u8]) -> Self {
+        Self { buf }
+    }
+}
+
+impl<'a> Iterator for ReadDir<'a> {
+    type Item = DirEntry;
+
+    fn next(&mut self) -> Option<DirEntry> {
+        unsafe {
+            if self.buf.len() == 0 {
+                return None;
+            }
+
+            // Read the data
+            let dirent_ptr = self.buf.as_ptr() as *const libc::__wasi_dirent_t;
+            let dirent = *dirent_ptr;
+            let name_ptr = dirent_ptr.offset(1) as *const u8;
+            // NOTE Linux syscall returns a NULL-terminated name, but WASI doesn't
+            let namelen = dirent.d_namlen as usize;
+            let slice = slice::from_raw_parts(name_ptr, namelen);
+            let name = str::from_utf8(slice).unwrap().to_owned();
+
+            // Update the internal state
+            let delta = mem::size_of_val(&dirent) + namelen;
+            self.buf = &self.buf[delta..];
+
+            DirEntry { dirent, name }.into()
+        }
+    }
+}
+
+fn test_fd_readdir(dir_fd: libc::__wasi_fd_t) {
+    let mut buf: [u8; BUF_LEN] = [0; BUF_LEN];
+    let mut bufused = unsafe { mem::zeroed() };
+    let status = wasi_fd_readdir(dir_fd, &mut buf, BUF_LEN, 0, &mut bufused);
+    assert_eq!(status, libc::__WASI_ESUCCESS, "fd_readdir");
+    // Create a file in the scratch directory.
+
+    let sl = unsafe { slice::from_raw_parts(buf.as_ptr(), min(BUF_LEN, bufused)) };
+    let mut dirs = ReadDir::from_slice(sl);
+
+    // the first entry should be `.`
+    let dir = dirs.next().unwrap();
+    assert_eq!(dir.name, ".", "first name");
+    assert_eq!(
+        dir.dirent.d_type,
+        libc::__WASI_FILETYPE_REGULAR_FILE,
+        "first type"
+    ); // WHY??
+
+    // the second entry should be `..`
+    let dir = dirs.next().unwrap();
+    assert_eq!(dir.name, "..", "second name");
+    assert_eq!(
+        dir.dirent.d_type,
+        libc::__WASI_FILETYPE_REGULAR_FILE,
+        "second type"
+    ); // WHY??
+
+    assert!(
+        dirs.next().is_none(),
+        "the directory should be seen as empty"
+    );
+}
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    test_fd_readdir(dir_fd)
+}

--- a/src/bin/fd_readdir.rs
+++ b/src/bin/fd_readdir.rs
@@ -130,7 +130,7 @@ fn test_fd_readdir(dir_fd: wasi_unstable::Fd) {
     assert_eq!(dirs.len(), 3, "expected three entries");
     // Save the data about the last entry. We need to do it before sorting.
     let lastfile_cookie = dirs[1].dirent.d_next;
-    let lastfile_name = dirs[1].name.clone();
+    let lastfile_name = dirs[2].name.clone();
     dirs.sort_by_key(|d| d.name.clone());
     let mut dirs = dirs.into_iter();
 

--- a/src/bin/fd_readdir.rs
+++ b/src/bin/fd_readdir.rs
@@ -66,7 +66,9 @@ fn test_fd_readdir(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory.
 
     let sl = unsafe { slice::from_raw_parts(buf.as_ptr(), min(BUF_LEN, bufused)) };
-    let mut dirs = ReadDir::from_slice(sl);
+    let mut dirs: Vec<_> = ReadDir::from_slice(sl).collect();
+    dirs.sort_by_key(|d| d.name.clone());
+    let mut dirs = dirs.into_iter();
 
     // the first entry should be `.`
     let dir = dirs.next().expect("first entry is None");

--- a/src/bin/fd_readdir.rs
+++ b/src/bin/fd_readdir.rs
@@ -2,6 +2,7 @@ use libc;
 use misc_tests::open_scratch_directory;
 use misc_tests::wasi_wrappers::{wasi_fd_filestat_get, wasi_fd_readdir};
 use std::{cmp::min, env, mem, process, slice, str};
+use wasi::wasi_unstable;
 
 const BUF_LEN: usize = 256;
 
@@ -49,8 +50,8 @@ impl<'a> Iterator for ReadDir<'a> {
     }
 }
 
-fn test_fd_readdir(dir_fd: libc::__wasi_fd_t) {
-    let mut stat: libc::__wasi_filestat_t = unsafe { mem::zeroed() };
+fn test_fd_readdir(dir_fd: wasi_unstable::Fd) {
+    let mut stat: wasi_unstable::FileStat = unsafe { mem::zeroed() };
     let status = wasi_fd_filestat_get(dir_fd, &mut stat);
     assert_eq!(
         status,

--- a/src/bin/fd_readdir.rs
+++ b/src/bin/fd_readdir.rs
@@ -1,6 +1,6 @@
 use libc;
 use misc_tests::open_scratch_directory;
-use misc_tests::wasi_wrappers::wasi_fd_readdir;
+use misc_tests::wasi_wrappers::{wasi_fd_filestat_get, wasi_fd_readdir};
 use std::{cmp::min, env, mem, process, slice, str};
 
 const BUF_LEN: usize = 256;
@@ -38,7 +38,7 @@ impl<'a> Iterator for ReadDir<'a> {
             // NOTE Linux syscall returns a NULL-terminated name, but WASI doesn't
             let namelen = dirent.d_namlen as usize;
             let slice = slice::from_raw_parts(name_ptr, namelen);
-            let name = str::from_utf8(slice).unwrap().to_owned();
+            let name = str::from_utf8(slice).expect("invalid utf8").to_owned();
 
             // Update the internal state
             let delta = mem::size_of_val(&dirent) + namelen;
@@ -50,6 +50,14 @@ impl<'a> Iterator for ReadDir<'a> {
 }
 
 fn test_fd_readdir(dir_fd: libc::__wasi_fd_t) {
+    let mut stat: libc::__wasi_filestat_t = unsafe { mem::zeroed() };
+    let status = wasi_fd_filestat_get(dir_fd, &mut stat);
+    assert_eq!(
+        status,
+        libc::__WASI_ESUCCESS,
+        "reading scratch directory stats"
+    );
+
     let mut buf: [u8; BUF_LEN] = [0; BUF_LEN];
     let mut bufused = unsafe { mem::zeroed() };
     let status = wasi_fd_readdir(dir_fd, &mut buf, BUF_LEN, 0, &mut bufused);
@@ -67,6 +75,8 @@ fn test_fd_readdir(dir_fd: libc::__wasi_fd_t) {
         libc::__WASI_FILETYPE_REGULAR_FILE,
         "first type"
     ); // WHY??
+    assert_eq!(dir.dirent.d_ino, stat.st_ino);
+    assert_eq!(dir.dirent.d_namlen, 1);
 
     // the second entry should be `..`
     let dir = dirs.next().expect("second entry is None");

--- a/src/bin/fd_readdir.rs
+++ b/src/bin/fd_readdir.rs
@@ -59,7 +59,6 @@ fn exec_fd_readdir(fd: wasi_unstable::Fd, cookie: wasi_unstable::DirCookie) -> V
 
     let sl = unsafe { slice::from_raw_parts(buf.as_ptr(), min(BUF_LEN, bufused)) };
     let dirs: Vec<_> = ReadDir::from_slice(sl).collect();
-    println!("{:?}", dirs);
     dirs
 }
 
@@ -124,7 +123,6 @@ fn test_fd_readdir(dir_fd: wasi_unstable::Fd) {
     let status = wasi_fd_filestat_get(file_fd, &mut stat);
     assert_eq!(status, wasi_unstable::ESUCCESS, "reading file stats");
 
-    println!("Executing another readdir");
     // Execute another readdir
     let mut dirs = exec_fd_readdir(dir_fd, wasi_unstable::DIRCOOKIE_START);
     assert_eq!(dirs.len(), 3, "expected three entries");

--- a/src/bin/fd_readdir.rs
+++ b/src/bin/fd_readdir.rs
@@ -60,7 +60,7 @@ fn test_fd_readdir(dir_fd: libc::__wasi_fd_t) {
     let mut dirs = ReadDir::from_slice(sl);
 
     // the first entry should be `.`
-    let dir = dirs.next().unwrap();
+    let dir = dirs.next().expect("first entry is None");
     assert_eq!(dir.name, ".", "first name");
     assert_eq!(
         dir.dirent.d_type,
@@ -69,7 +69,7 @@ fn test_fd_readdir(dir_fd: libc::__wasi_fd_t) {
     ); // WHY??
 
     // the second entry should be `..`
-    let dir = dirs.next().unwrap();
+    let dir = dirs.next().expect("second entry is None");
     assert_eq!(dir.name, "..", "second name");
     assert_eq!(
         dir.dirent.d_type,

--- a/src/bin/fd_readdir.rs
+++ b/src/bin/fd_readdir.rs
@@ -83,9 +83,9 @@ fn test_fd_readdir(dir_fd: wasi_unstable::Fd) {
     assert_eq!(dir.name, ".", "first name");
     assert_eq!(
         dir.dirent.d_type,
-        wasi_unstable::FILETYPE_REGULAR_FILE,
+        wasi_unstable::FILETYPE_DIRECTORY,
         "first type"
-    ); // WHY??
+    );
     assert_eq!(dir.dirent.d_ino, stat.st_ino);
     assert_eq!(dir.dirent.d_namlen, 1);
 
@@ -94,9 +94,9 @@ fn test_fd_readdir(dir_fd: wasi_unstable::Fd) {
     assert_eq!(dir.name, "..", "second name");
     assert_eq!(
         dir.dirent.d_type,
-        wasi_unstable::FILETYPE_REGULAR_FILE,
+        wasi_unstable::FILETYPE_DIRECTORY,
         "second type"
-    ); // WHY??
+    );
 
     assert!(
         dirs.next().is_none(),

--- a/src/bin/fd_readdir.rs
+++ b/src/bin/fd_readdir.rs
@@ -151,7 +151,7 @@ fn test_fd_readdir(dir_fd: wasi_unstable::Fd) {
     // check if cookie works as expected
     let dirs = exec_fd_readdir(dir_fd, lastfile_cookie);
     assert_eq!(dirs.len(), 1, "expected one entry");
-    assert_eq!(dirs[0].name, lastfile_name, "expected file to be the only entry");
+    assert_eq!(dirs[0].name, lastfile_name, "name of the only entry");
 }
 
 fn main() {

--- a/src/wasi_wrappers.rs
+++ b/src/wasi_wrappers.rs
@@ -198,6 +198,20 @@ pub fn wasi_path_filestat_set_times(
             st_atim,
             st_mtim,
             fst_flags,
+pub fn wasi_fd_readdir(
+    fd: wasi_unstable::Fd,
+    buf: &mut [u8],
+    buf_len: usize,
+    cookie: wasi_unstable::DirCookie,
+    buf_used: &mut usize,
+) -> wasi_unstable::Errno {
+    unsafe {
+        wasi_unstable::raw::__wasi_fd_readdir(
+            fd,
+            buf.as_mut_ptr() as *mut libc::c_void,
+            buf_len,
+            cookie,
+            buf_used,
         )
     }
 }

--- a/src/wasi_wrappers.rs
+++ b/src/wasi_wrappers.rs
@@ -197,7 +197,11 @@ pub fn wasi_path_filestat_set_times(
             path_len,
             st_atim,
             st_mtim,
-            fst_flags,
+            fst_flags
+        )
+    }
+}
+
 pub fn wasi_fd_readdir(
     fd: wasi_unstable::Fd,
     buf: &mut [u8],


### PR DESCRIPTION
There are still some unclarities to be resolved before merging:
* [x] `readdir(2)` shows that the filename (`d_name`) should be null-terminated but the current implementation doesn't null-terminate the filename. Is this intended? This looks like something that may cause problems for programs written in C
* [x] what are the semantics of `dircookie_t` and why is it a separate type? `readdir(2)` is just using a `long`. What are the semantics of the `cookie` input parameter? The docs say that: _The location within the directory to start reading._, which is unclear to me. In particular, the test should test the behavior with `cookie != 0`
* [x] why is `.` a regular file and not a directory?