### PR TITLE
Update to wasi 0.7.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,22 +2,22 @@
 # It is not intended for manual editing.
 [[package]]
 name = "libc"
-version = "0.2.60"
-source = "git+https://github.com/rust-lang/libc#2b01f7e67322175e05f25325e6e941aa9a3ddeae"
-
-[[package]]
-name = "misc-tests"
-version = "0.1.0"
-dependencies = [
- "libc 0.2.60 (git+https://github.com/rust-lang/libc)",
- "wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+version = "0.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasi"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "wasi-misc-tests"
+version = "0.1.0"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
-"checksum libc 0.2.60 (git+https://github.com/rust-lang/libc)" = "<none>"
-"checksum wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd5442abcac6525a045cc8c795aedb60da7a2e5e89c7bf18a0d5357849bb23c7"
+"checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
+"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Dan Gohman <sunfish@mozilla.com>", "Jakub Konka <kubkon@jakubkonka.c
 edition = "2018"
 
 [dependencies]
-libc = { git = "https://github.com/rust-lang/libc" }
-wasi = "0.5.0"
+libc = "0.2.62"
+wasi = "0.7.0"

--- a/src/bin/big_random_buf.rs
+++ b/src/bin/big_random_buf.rs
@@ -3,10 +3,8 @@ use wasi::wasi_unstable;
 fn test_big_random_buf() {
     let mut buf = Vec::new();
     buf.resize(1024, 0);
-    let status = wasi_unstable::random_get(&mut buf);
-    assert_eq!(
-        status,
-        wasi_unstable::ESUCCESS,
+    assert!(
+        wasi_unstable::random_get(&mut buf).is_ok(),
         "calling get_random on a large buffer"
     );
     // Chances are pretty good that at least *one* byte will be non-zero in

--- a/src/bin/clock_time_get.rs
+++ b/src/bin/clock_time_get.rs
@@ -1,7 +1,7 @@
 use wasi::wasi_unstable;
 use wasi_misc_tests::wasi_wrappers::wasi_clock_time_get;
 
-fn test_clock_time_get() {
+unsafe fn test_clock_time_get() {
     // Test that clock_time_get succeeds. Even in environments where it's not
     // desirable to expose high-precision timers, it should still succeed.
     // clock_res_get is where information about precision can be provided.
@@ -9,19 +9,19 @@ fn test_clock_time_get() {
     let mut status = wasi_clock_time_get(wasi_unstable::CLOCK_MONOTONIC, 0, &mut time);
     assert_eq!(
         status,
-        wasi_unstable::ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "clock_time_get with a precision of 0"
     );
 
     status = wasi_clock_time_get(wasi_unstable::CLOCK_MONOTONIC, 1, &mut time);
     assert_eq!(
         status,
-        wasi_unstable::ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "clock_time_get with a precision of 1"
     );
 }
 
 fn main() {
     // Run the tests.
-    test_clock_time_get()
+    unsafe { test_clock_time_get() }
 }

--- a/src/bin/directory_seek.rs
+++ b/src/bin/directory_seek.rs
@@ -5,7 +5,7 @@ use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_dir, close_fd, create_dir};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_fdstat_get, wasi_fd_seek, wasi_path_open};
 
-fn test_directory_seek(dir_fd: wasi_unstable::Fd) {
+unsafe fn test_directory_seek(dir_fd: wasi_unstable::Fd) {
     // Create a directory in the scratch directory.
     create_dir(dir_fd, "dir");
 
@@ -21,7 +21,11 @@ fn test_directory_seek(dir_fd: wasi_unstable::Fd) {
         0,
         &mut fd,
     );
-    assert_eq!(status, wasi_unstable::ESUCCESS, "opening a file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "opening a file"
+    );
     assert!(
         fd > libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
@@ -30,14 +34,18 @@ fn test_directory_seek(dir_fd: wasi_unstable::Fd) {
     // Attempt to seek.
     let mut newoffset = 1;
     status = wasi_fd_seek(fd, 0, wasi_unstable::WHENCE_CUR, &mut newoffset);
-    assert_eq!(status, wasi_unstable::ENOTCAPABLE, "seek on a directory");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ENOTCAPABLE,
+        "seek on a directory"
+    );
 
     // Check if we obtained the right to seek.
-    let mut fdstat: wasi_unstable::FdStat = unsafe { mem::zeroed() };
+    let mut fdstat: wasi_unstable::FdStat = mem::zeroed();
     status = wasi_fd_fdstat_get(fd, &mut fdstat);
     assert_eq!(
         status,
-        wasi_unstable::ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "calling fd_fdstat on a directory"
     );
     assert!(
@@ -75,5 +83,5 @@ fn main() {
     };
 
     // Run the tests.
-    test_directory_seek(dir_fd)
+    unsafe { test_directory_seek(dir_fd) }
 }

--- a/src/bin/file_pread_pwrite.rs
+++ b/src/bin/file_pread_pwrite.rs
@@ -5,7 +5,7 @@ use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_pread, wasi_fd_pwrite, wasi_path_open};
 
-fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
+unsafe fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory.
     let mut file_fd = wasi_unstable::Fd::max_value() - 1;
     let mut status = wasi_path_open(
@@ -18,7 +18,11 @@ fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
         0,
         &mut file_fd,
     );
-    assert_eq!(status, wasi_unstable::ESUCCESS, "opening a file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "opening a file"
+    );
     assert!(
         file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
@@ -31,7 +35,11 @@ fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
     };
     let mut nwritten = 0;
     status = wasi_fd_pwrite(file_fd, &mut [ciovec], 0, &mut nwritten);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "writing bytes at offset 0");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "writing bytes at offset 0"
+    );
     assert_eq!(nwritten, 4, "nwritten bytes check");
 
     let contents = &mut [0u8; 4];
@@ -41,7 +49,11 @@ fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
     };
     let mut nread = 0;
     status = wasi_fd_pread(file_fd, &[iovec], 0, &mut nread);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "reading bytes at offset 0");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "reading bytes at offset 0"
+    );
     assert_eq!(nread, 4, "nread bytes check");
     assert_eq!(contents, &[0u8, 1, 2, 3], "written bytes equal read bytes");
 
@@ -52,7 +64,11 @@ fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
     };
     let mut nread = 0;
     status = wasi_fd_pread(file_fd, &[iovec], 2, &mut nread);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "reading bytes at offset 2");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "reading bytes at offset 2"
+    );
     assert_eq!(nread, 2, "nread bytes check");
     assert_eq!(contents, &[2u8, 3, 0, 0], "file cursor was overwritten");
 
@@ -63,7 +79,11 @@ fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
     };
     let mut nwritten = 0;
     status = wasi_fd_pwrite(file_fd, &mut [ciovec], 2, &mut nwritten);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "writing bytes at offset 2");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "writing bytes at offset 2"
+    );
     assert_eq!(nwritten, 2, "nwritten bytes check");
 
     let contents = &mut [0u8; 4];
@@ -73,13 +93,18 @@ fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
     };
     let mut nread = 0;
     status = wasi_fd_pread(file_fd, &[iovec], 0, &mut nread);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "reading bytes at offset 0");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "reading bytes at offset 0"
+    );
     assert_eq!(nread, 4, "nread bytes check");
     assert_eq!(contents, &[0u8, 1, 1, 0], "file cursor was overwritten");
 
     close_fd(file_fd);
     cleanup_file(dir_fd, "file");
 }
+
 fn main() {
     let mut args = env::args();
     let prog = args.next().unwrap();
@@ -100,5 +125,5 @@ fn main() {
     };
 
     // Run the tests.
-    test_file_pread_pwrite(dir_fd)
+    unsafe { test_file_pread_pwrite(dir_fd) }
 }

--- a/src/bin/file_seek_tell.rs
+++ b/src/bin/file_seek_tell.rs
@@ -5,7 +5,7 @@ use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_seek, wasi_fd_tell, wasi_fd_write, wasi_path_open};
 
-fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
+unsafe fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory.
     let mut file_fd = wasi_unstable::Fd::max_value() - 1;
     let mut status = wasi_path_open(
@@ -18,7 +18,11 @@ fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
         0,
         &mut file_fd,
     );
-    assert_eq!(status, wasi_unstable::ESUCCESS, "opening a file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "opening a file"
+    );
     assert!(
         file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
@@ -29,7 +33,7 @@ fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
     status = wasi_fd_tell(file_fd, &mut offset);
     assert_eq!(
         status,
-        wasi_unstable::ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "getting initial file offset"
     );
     assert_eq!(offset, 0, "current offset should be 0");
@@ -43,14 +47,18 @@ fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
     let iovs = &[iov];
     let mut nwritten = 0;
     status = wasi_fd_write(file_fd, iovs, &mut nwritten);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "writing to a file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "writing to a file"
+    );
     assert_eq!(nwritten, 100, "should write 100 bytes to file");
 
     // Check current offset
     status = wasi_fd_tell(file_fd, &mut offset);
     assert_eq!(
         status,
-        wasi_unstable::ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "getting file offset after writing"
     );
     assert_eq!(offset, 100, "offset after writing should be 100");
@@ -60,7 +68,7 @@ fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
     status = wasi_fd_seek(file_fd, -50, wasi_unstable::WHENCE_CUR, &mut newoffset);
     assert_eq!(
         status,
-        wasi_unstable::ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "seeking to the middle of a file"
     );
     assert_eq!(
@@ -72,7 +80,7 @@ fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
     status = wasi_fd_seek(file_fd, 0, wasi_unstable::WHENCE_SET, &mut newoffset);
     assert_eq!(
         status,
-        wasi_unstable::ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "seeking to the beginning of the file"
     );
     assert_eq!(
@@ -84,7 +92,7 @@ fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
     status = wasi_fd_seek(file_fd, 1000, wasi_unstable::WHENCE_CUR, &mut newoffset);
     assert_eq!(
         status,
-        wasi_unstable::ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "seeking beyond the end of the file"
     );
 
@@ -92,7 +100,7 @@ fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
     status = wasi_fd_seek(file_fd, -2000, wasi_unstable::WHENCE_CUR, &mut newoffset);
     assert_eq!(
         status,
-        wasi_unstable::EINVAL,
+        wasi_unstable::raw::__WASI_EINVAL,
         "seeking before byte 0 is an error"
     );
 
@@ -119,5 +127,5 @@ fn main() {
     };
 
     // Run the tests.
-    test_file_seek_tell(dir_fd)
+    unsafe { test_file_seek_tell(dir_fd) }
 }

--- a/src/bin/file_unbuffered_write.rs
+++ b/src/bin/file_unbuffered_write.rs
@@ -5,7 +5,7 @@ use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd, create_file};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_read, wasi_fd_write, wasi_path_open};
 
-fn test_file_unbuffered_write(dir_fd: wasi_unstable::Fd) {
+unsafe fn test_file_unbuffered_write(dir_fd: wasi_unstable::Fd) {
     // Create file
     create_file(dir_fd, "file");
 
@@ -21,7 +21,11 @@ fn test_file_unbuffered_write(dir_fd: wasi_unstable::Fd) {
         0,
         &mut fd_read,
     );
-    assert_eq!(status, wasi_unstable::ESUCCESS, "opening a file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "opening a file"
+    );
     assert!(
         fd_read > libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
@@ -39,7 +43,11 @@ fn test_file_unbuffered_write(dir_fd: wasi_unstable::Fd) {
         0,
         &mut fd_write,
     );
-    assert_eq!(status, wasi_unstable::ESUCCESS, "opening a file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "opening a file"
+    );
     assert!(
         fd_write > libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
@@ -53,7 +61,11 @@ fn test_file_unbuffered_write(dir_fd: wasi_unstable::Fd) {
     };
     let mut nwritten = 0;
     status = wasi_fd_write(fd_write, &[ciovec], &mut nwritten);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "writing byte to file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "writing byte to file"
+    );
     assert_eq!(nwritten, 1, "nwritten bytes check");
 
     // Read from file
@@ -64,7 +76,11 @@ fn test_file_unbuffered_write(dir_fd: wasi_unstable::Fd) {
     };
     let mut nread = 0;
     status = wasi_fd_read(fd_read, &[iovec], &mut nread);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "reading bytes from file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "reading bytes from file"
+    );
     assert_eq!(nread, 1, "nread bytes check");
     assert_eq!(contents, &[1u8], "written bytes equal read bytes");
 
@@ -93,5 +109,5 @@ fn main() {
     };
 
     // Run the tests.
-    test_file_unbuffered_write(dir_fd)
+    unsafe { test_file_unbuffered_write(dir_fd) }
 }

--- a/src/bin/isatty.rs
+++ b/src/bin/isatty.rs
@@ -5,7 +5,7 @@ use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd};
 use wasi_misc_tests::wasi_wrappers::wasi_path_open;
 
-fn test_isatty(dir_fd: wasi_unstable::Fd) {
+unsafe fn test_isatty(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory and test if it's a tty.
     let mut file_fd: wasi_unstable::Fd = wasi_unstable::Fd::max_value() - 1;
     let status = wasi_path_open(
@@ -18,13 +18,17 @@ fn test_isatty(dir_fd: wasi_unstable::Fd) {
         0,
         &mut file_fd,
     );
-    assert_eq!(status, wasi_unstable::ESUCCESS, "opening a file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "opening a file"
+    );
     assert!(
         file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
     assert_eq!(
-        unsafe { libc::isatty(file_fd as std::os::raw::c_int) },
+        libc::isatty(file_fd as std::os::raw::c_int),
         0,
         "file is a tty"
     );
@@ -53,5 +57,5 @@ fn main() {
     };
 
     // Run the tests.
-    test_isatty(dir_fd)
+    unsafe { test_isatty(dir_fd) }
 }

--- a/src/bin/path_filestat.rs
+++ b/src/bin/path_filestat.rs
@@ -7,57 +7,61 @@ use wasi_misc_tests::wasi_wrappers::{
     wasi_fd_fdstat_get, wasi_path_filestat_get, wasi_path_filestat_set_times, wasi_path_open,
 };
 
-fn test_path_filestat(dir_fd: libc::__wasi_fd_t) {
-    let mut fdstat: wasi_unstable::FdStat = unsafe { std::mem::zeroed() };
+unsafe fn test_path_filestat(dir_fd: wasi_unstable::Fd) {
+    let mut fdstat: wasi_unstable::FdStat = std::mem::zeroed();
     let status = wasi_fd_fdstat_get(dir_fd, &mut fdstat);
-    assert_eq!(status, libc::__WASI_ESUCCESS, "fd_fdstat_get");
+    assert_eq!(status, wasi_unstable::raw::__WASI_ESUCCESS, "fd_fdstat_get");
 
     assert!(
-        (fdstat.fs_rights_base & libc::__WASI_RIGHT_PATH_FILESTAT_GET) != 0,
-        "the scratch directory should have __WASI_RIGHT_PATH_FILESTAT_GET as base right",
+        (fdstat.fs_rights_base & wasi_unstable::RIGHT_PATH_FILESTAT_GET) != 0,
+        "the scratch directory should have RIGHT_PATH_FILESTAT_GET as base right",
     );
     assert!(
-        (fdstat.fs_rights_inheriting & libc::__WASI_RIGHT_PATH_FILESTAT_GET) != 0,
-        "the scratch directory should have __WASI_RIGHT_PATH_FILESTAT_GET as base right",
+        (fdstat.fs_rights_inheriting & wasi_unstable::RIGHT_PATH_FILESTAT_GET) != 0,
+        "the scratch directory should have RIGHT_PATH_FILESTAT_GET as base right",
     );
 
     // Create a file in the scratch directory.
-    let mut file_fd = libc::__wasi_fd_t::max_value() - 1;
+    let mut file_fd = wasi_unstable::Fd::max_value() - 1;
     let filename = "file";
     let status = wasi_path_open(
         dir_fd,
         0,
         filename,
-        libc::__WASI_O_CREAT,
-        libc::__WASI_RIGHT_FD_READ
-            | libc::__WASI_RIGHT_FD_WRITE
-            | libc::__WASI_RIGHT_PATH_FILESTAT_GET,
+        wasi_unstable::O_CREAT,
+        wasi_unstable::RIGHT_FD_READ
+            | wasi_unstable::RIGHT_FD_WRITE
+            | wasi_unstable::RIGHT_PATH_FILESTAT_GET,
         0,
         0,
         &mut file_fd,
     );
-    assert_eq!(status, libc::__WASI_ESUCCESS, "opening a file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "opening a file"
+    );
     assert!(
-        file_fd > libc::STDERR_FILENO as libc::__wasi_fd_t,
+        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 
     let status = wasi_fd_fdstat_get(file_fd, &mut fdstat);
-    assert_eq!(status, libc::__WASI_ESUCCESS, "fd_fdstat_get");
+    assert_eq!(status, wasi_unstable::raw::__WASI_ESUCCESS, "fd_fdstat_get");
 
     assert_eq!(
-        fdstat.fs_rights_base & libc::__WASI_RIGHT_PATH_FILESTAT_GET,
+        fdstat.fs_rights_base & wasi_unstable::RIGHT_PATH_FILESTAT_GET,
         0,
         "files shouldn't have rights for path_* syscalls even if manually given",
     );
     assert_eq!(
-        fdstat.fs_rights_inheriting & libc::__WASI_RIGHT_PATH_FILESTAT_GET,
+        fdstat.fs_rights_inheriting & wasi_unstable::RIGHT_PATH_FILESTAT_GET,
         0,
         "files shouldn't have rights for path_* syscalls even if manually given",
     );
 
     // Check file size
-    let mut stat = libc::__wasi_filestat_t {
+    let mut stat = wasi_unstable::FileStat {
         st_dev: 0,
         st_ino: 0,
         st_filetype: 0,
@@ -68,46 +72,50 @@ fn test_path_filestat(dir_fd: libc::__wasi_fd_t) {
         st_ctim: 0,
     };
     let status = wasi_path_filestat_get(dir_fd, 0, filename, filename.len(), &mut stat);
-    assert_eq!(status, libc::__WASI_ESUCCESS, "reading file stats");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "reading file stats"
+    );
     assert_eq!(stat.st_size, 0, "file size should be 0");
 
     // Check path_filestat_set_times
     let old_atim = stat.st_atim;
     let new_mtim = stat.st_mtim - 100;
-    let status = wasi_path_filestat_set_times(
-        dir_fd,
-        0,
-        filename,
-        filename.len(),
-        // on purpose: the syscall should not touch atim, because
-        // neither of the ATIM flags is set
-        new_mtim,
-        new_mtim,
-        libc::__WASI_FILESTAT_SET_MTIM,
+    assert!(
+        wasi_path_filestat_set_times(
+            dir_fd,
+            0,
+            filename,
+            // on purpose: the syscall should not touch atim, because
+            // neither of the ATIM flags is set
+            new_mtim,
+            new_mtim,
+            wasi_unstable::FILESTAT_SET_MTIM,
+        )
+        .is_ok(),
+        "fd_filestat_set_times"
     );
-    assert_eq!(status, libc::__WASI_ESUCCESS, "fd_filestat_set_times");
 
     let status = wasi_path_filestat_get(dir_fd, 0, filename, filename.len(), &mut stat);
     assert_eq!(
         status,
-        libc::__WASI_ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "reading file stats after fd_filestat_set_times"
     );
     assert_eq!(stat.st_mtim, new_mtim, "mtim should change");
     assert_eq!(stat.st_atim, old_atim, "atim should not change");
 
-    let status = wasi_path_filestat_set_times(
-        dir_fd,
-        0,
-        filename,
-        filename.len(),
-        new_mtim,
-        new_mtim,
-        libc::__WASI_FILESTAT_SET_MTIM | libc::__WASI_FILESTAT_SET_MTIM_NOW,
-    );
-    assert_eq!(
-        status,
-        libc::__WASI_EINVAL,
+    assert!(
+        wasi_path_filestat_set_times(
+            dir_fd,
+            0,
+            filename,
+            new_mtim,
+            new_mtim,
+            wasi_unstable::FILESTAT_SET_MTIM | wasi_unstable::FILESTAT_SET_MTIM_NOW,
+        )
+        .is_ok(),
         "ATIM & ATIM_NOW can't both be set"
     );
 
@@ -115,7 +123,7 @@ fn test_path_filestat(dir_fd: libc::__wasi_fd_t) {
     let status = wasi_path_filestat_get(dir_fd, 0, filename, filename.len(), &mut stat);
     assert_eq!(
         status,
-        libc::__WASI_ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "reading file stats after EINVAL fd_filestat_set_times"
     );
     assert_eq!(stat.st_mtim, new_mtim, "mtim should not change");
@@ -144,5 +152,5 @@ fn main() {
     };
 
     // Run the tests.
-    test_path_filestat(dir_fd)
+    unsafe { test_path_filestat(dir_fd) }
 }

--- a/src/bin/readlink.rs
+++ b/src/bin/readlink.rs
@@ -4,19 +4,25 @@ use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, create_file};
 use wasi_misc_tests::wasi_wrappers::{wasi_path_readlink, wasi_path_symlink};
 
-fn test_readlink(dir_fd: wasi_unstable::Fd) {
+unsafe fn test_readlink(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory.
     create_file(dir_fd, "target");
 
     // Create a symlink
-    let mut status = wasi_path_symlink("target", dir_fd, "symlink");
-    assert_eq!(status, wasi_unstable::ESUCCESS, "creating a symlink");
+    assert!(
+        wasi_path_symlink("target", dir_fd, "symlink").is_ok(),
+        "creating a symlink"
+    );
 
     // Read link into the buffer
     let buf = &mut [0u8; 10];
     let mut bufused: usize = 0;
-    status = wasi_path_readlink(dir_fd, "symlink", buf, &mut bufused);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "readlink should succeed");
+    let mut status = wasi_path_readlink(dir_fd, "symlink", buf, &mut bufused);
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "readlink should succeed"
+    );
     assert_eq!(bufused, 6, "should use 6 bytes of the buffer");
     assert_eq!(&buf[..6], b"target", "buffer should contain 'target'");
     assert_eq!(
@@ -29,7 +35,11 @@ fn test_readlink(dir_fd: wasi_unstable::Fd) {
     let buf = &mut [0u8; 4];
     let mut bufused: usize = 0;
     status = wasi_path_readlink(dir_fd, "symlink", buf, &mut bufused);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "readlink should succeed");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "readlink should succeed"
+    );
     assert_eq!(bufused, 4, "should use all 4 bytes of the buffer");
     assert_eq!(buf, b"targ", "buffer should contain 'targ'");
 
@@ -37,6 +47,7 @@ fn test_readlink(dir_fd: wasi_unstable::Fd) {
     cleanup_file(dir_fd, "target");
     cleanup_file(dir_fd, "symlink");
 }
+
 fn main() {
     let mut args = env::args();
     let prog = args.next().unwrap();
@@ -57,5 +68,5 @@ fn main() {
     };
 
     // Run the tests.
-    test_readlink(dir_fd)
+    unsafe { test_readlink(dir_fd) }
 }

--- a/src/bin/readlink_no_buffer.rs
+++ b/src/bin/readlink_no_buffer.rs
@@ -4,17 +4,19 @@ use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::cleanup_file;
 use wasi_misc_tests::wasi_wrappers::{wasi_path_readlink, wasi_path_symlink};
 
-fn test_readlink_no_buffer(dir_fd: wasi_unstable::Fd) {
+unsafe fn test_readlink_no_buffer(dir_fd: wasi_unstable::Fd) {
     // First create a dangling symlink.
-    let mut status = wasi_path_symlink("target", dir_fd, "symlink");
-    assert_eq!(status, wasi_unstable::ESUCCESS, "creating a symlink");
+    assert!(
+        wasi_path_symlink("target", dir_fd, "symlink").is_ok(),
+        "creating a symlink"
+    );
 
     // Readlink it into a non-existent buffer.
     let mut bufused: usize = 1;
-    status = wasi_path_readlink(dir_fd, "symlink", &mut [], &mut bufused);
+    let status = wasi_path_readlink(dir_fd, "symlink", &mut [], &mut bufused);
     assert_eq!(
         status,
-        wasi_unstable::ESUCCESS,
+        wasi_unstable::raw::__WASI_ESUCCESS,
         "readlink with a 0-sized buffer should succeed"
     );
     assert_eq!(
@@ -45,5 +47,5 @@ fn main() {
     };
 
     // Run the tests.
-    test_readlink_no_buffer(dir_fd)
+    unsafe { test_readlink_no_buffer(dir_fd) }
 }

--- a/src/bin/remove_nonempty_directory.rs
+++ b/src/bin/remove_nonempty_directory.rs
@@ -4,7 +4,7 @@ use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_dir, create_dir};
 use wasi_misc_tests::wasi_wrappers::wasi_path_remove_directory;
 
-fn test_remove_nonempty_directory(dir_fd: wasi_unstable::Fd) {
+unsafe fn test_remove_nonempty_directory(dir_fd: wasi_unstable::Fd) {
     // Create a directory in the scratch directory.
     create_dir(dir_fd, "dir");
 
@@ -12,18 +12,15 @@ fn test_remove_nonempty_directory(dir_fd: wasi_unstable::Fd) {
     create_dir(dir_fd, "dir/nested");
 
     // Test that attempting to unlink the first directory returns the expected error code.
-    let mut status = wasi_path_remove_directory(dir_fd, "dir");
     assert_eq!(
-        status,
-        wasi_unstable::ENOTEMPTY,
+        wasi_path_remove_directory(dir_fd, "dir"),
+        Err(wasi_unstable::ENOTEMPTY),
         "remove_directory on a directory should return ENOTEMPTY",
     );
 
     // Removing the directories.
-    status = wasi_path_remove_directory(dir_fd, "dir/nested");
-    assert_eq!(
-        status,
-        wasi_unstable::ESUCCESS,
+    assert!(
+        wasi_path_remove_directory(dir_fd, "dir/nested").is_ok(),
         "remove_directory on a nested directory should succeed",
     );
     cleanup_dir(dir_fd, "dir");
@@ -49,5 +46,5 @@ fn main() {
     };
 
     // Run the tests.
-    test_remove_nonempty_directory(dir_fd)
+    unsafe { test_remove_nonempty_directory(dir_fd) }
 }

--- a/src/bin/sched_yield.rs
+++ b/src/bin/sched_yield.rs
@@ -1,8 +1,7 @@
 use wasi::wasi_unstable;
 
 fn test_sched_yield() {
-    let status = wasi_unstable::sched_yield();
-    assert_eq!(status, wasi_unstable::ESUCCESS, "sched_yield");
+    assert!(wasi_unstable::sched_yield().is_ok(), "sched_yield");
 }
 
 fn main() {

--- a/src/bin/unlink_directory.rs
+++ b/src/bin/unlink_directory.rs
@@ -4,15 +4,14 @@ use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_dir, create_dir};
 use wasi_misc_tests::wasi_wrappers::wasi_path_unlink_file;
 
-fn test_unlink_directory(dir_fd: wasi_unstable::Fd) {
+unsafe fn test_unlink_directory(dir_fd: wasi_unstable::Fd) {
     // Create a directory in the scratch directory.
     create_dir(dir_fd, "dir");
 
     // Test that unlinking it fails.
-    let status = wasi_path_unlink_file(dir_fd, "dir");
     assert_eq!(
-        status,
-        wasi_unstable::EISDIR,
+        wasi_path_unlink_file(dir_fd, "dir"),
+        Err(wasi_unstable::EISDIR),
         "unlink_file on a directory should fail"
     );
 
@@ -40,5 +39,5 @@ fn main() {
     };
 
     // Run the tests.
-    test_unlink_directory(dir_fd)
+    unsafe { test_unlink_directory(dir_fd) }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,22 +1,22 @@
 use crate::wasi_wrappers::*;
 use wasi::wasi_unstable;
 
-pub fn create_dir(dir_fd: wasi_unstable::Fd, dir_name: &str) {
-    let status = wasi_path_create_directory(dir_fd, dir_name);
-    assert_eq!(status, wasi_unstable::ESUCCESS, "creating a directory");
+pub unsafe fn create_dir(dir_fd: wasi_unstable::Fd, dir_name: &str) {
+    assert!(
+        wasi_path_create_directory(dir_fd, dir_name).is_ok(),
+        "creating a directory"
+    );
 }
 
-pub fn cleanup_dir(dir_fd: wasi_unstable::Fd, dir_name: &str) {
-    let status = wasi_path_remove_directory(dir_fd, dir_name);
-    assert_eq!(
-        status,
-        wasi_unstable::ESUCCESS,
+pub unsafe fn cleanup_dir(dir_fd: wasi_unstable::Fd, dir_name: &str) {
+    assert!(
+        wasi_path_remove_directory(dir_fd, dir_name).is_ok(),
         "remove_directory on an empty directory should succeed"
     );
 }
 
 /// Create an empty file with the given name.
-pub fn create_file(dir_fd: wasi_unstable::Fd, file_name: &str) {
+pub unsafe fn create_file(dir_fd: wasi_unstable::Fd, file_name: &str) {
     let mut file_fd = wasi_unstable::Fd::max_value() - 1;
     let status = wasi_path_open(
         dir_fd,
@@ -28,7 +28,11 @@ pub fn create_file(dir_fd: wasi_unstable::Fd, file_name: &str) {
         0,
         &mut file_fd,
     );
-    assert_eq!(status, wasi_unstable::ESUCCESS, "creating a file");
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "creating a file"
+    );
     assert!(
         file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
@@ -36,19 +40,13 @@ pub fn create_file(dir_fd: wasi_unstable::Fd, file_name: &str) {
     close_fd(file_fd);
 }
 
-pub fn cleanup_file(dir_fd: wasi_unstable::Fd, file_name: &str) {
-    let status = wasi_path_unlink_file(dir_fd, file_name);
-    assert_eq!(
-        status,
-        wasi_unstable::ESUCCESS,
+pub unsafe fn cleanup_file(dir_fd: wasi_unstable::Fd, file_name: &str) {
+    assert!(
+        wasi_path_unlink_file(dir_fd, file_name).is_ok(),
         "unlink_file on a symlink should succeed"
     );
 }
 
-pub fn close_fd(fd: wasi_unstable::Fd) {
-    assert_eq!(
-        wasi_unstable::fd_close(fd),
-        wasi_unstable::ESUCCESS,
-        "closing a file"
-    );
+pub unsafe fn close_fd(fd: wasi_unstable::Fd) {
+    assert!(wasi_unstable::fd_close(fd).is_ok(), "closing a file");
 }

--- a/src/wasi_wrappers.rs
+++ b/src/wasi_wrappers.rs
@@ -1,28 +1,36 @@
 //! Minimal wrappers around WASI functions to allow use of `&str` rather than
 //! pointer-length pairs.
+//!
+//! Where possible, we use the idiomatic wasi_unstable wrappers rather than the
+//! raw interfaces, however for functions with out parameters, we use the raw
+//! interfaces so that we can test whether they are stored to. In the future,
+//! WASI should switch to multi-value and eliminate out parameters altogether.
 
 use wasi::wasi_unstable;
 
-pub fn wasi_path_create_directory(
+pub unsafe fn wasi_path_create_directory(
     dir_fd: wasi_unstable::Fd,
     dir_name: &str,
-) -> wasi_unstable::Errno {
+) -> Result<(), wasi_unstable::Error> {
     wasi_unstable::path_create_directory(dir_fd, dir_name.as_bytes())
 }
 
-pub fn wasi_path_remove_directory(
+pub unsafe fn wasi_path_remove_directory(
     dir_fd: wasi_unstable::Fd,
     dir_name: &str,
-) -> wasi_unstable::Errno {
+) -> Result<(), wasi_unstable::Error> {
     wasi_unstable::path_remove_directory(dir_fd, dir_name.as_bytes())
 }
 
-pub fn wasi_path_unlink_file(dir_fd: wasi_unstable::Fd, file_name: &str) -> wasi_unstable::Errno {
+pub unsafe fn wasi_path_unlink_file(
+    dir_fd: wasi_unstable::Fd,
+    file_name: &str,
+) -> Result<(), wasi_unstable::Error> {
     wasi_unstable::path_unlink_file(dir_fd, file_name.as_bytes())
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn wasi_path_open(
+pub unsafe fn wasi_path_open(
     dirfd: wasi_unstable::Fd,
     dirflags: wasi_unstable::LookupFlags,
     path: &str,
@@ -32,191 +40,169 @@ pub fn wasi_path_open(
     fs_flags: wasi_unstable::FdFlags,
     fd: &mut wasi_unstable::Fd,
 ) -> wasi_unstable::Errno {
-    unsafe {
-        wasi_unstable::raw::__wasi_path_open(
-            dirfd,
-            dirflags,
-            path.as_ptr(),
-            path.len(),
-            oflags,
-            fs_rights_base,
-            fs_rights_inheriting,
-            fs_flags,
-            fd,
-        )
-    }
+    wasi_unstable::raw::__wasi_path_open(
+        dirfd,
+        dirflags,
+        path.as_ptr(),
+        path.len(),
+        oflags,
+        fs_rights_base,
+        fs_rights_inheriting,
+        fs_flags,
+        fd,
+    )
 }
 
-pub fn wasi_path_symlink(
+pub unsafe fn wasi_path_symlink(
     old_path: &str,
     dirfd: wasi_unstable::Fd,
     new_path: &str,
-) -> wasi_unstable::Errno {
+) -> Result<(), wasi_unstable::Error> {
     wasi_unstable::path_symlink(old_path.as_bytes(), dirfd, new_path.as_bytes())
 }
 
-pub fn wasi_path_readlink(
+pub unsafe fn wasi_path_readlink(
     dirfd: wasi_unstable::Fd,
     path: &str,
     buf: &mut [u8],
     bufused: &mut usize,
 ) -> wasi_unstable::Errno {
-    unsafe {
-        wasi_unstable::raw::__wasi_path_readlink(
-            dirfd,
-            path.as_ptr(),
-            path.len(),
-            buf.as_mut_ptr(),
-            buf.len(),
-            bufused,
-        )
-    }
+    wasi_unstable::raw::__wasi_path_readlink(
+        dirfd,
+        path.as_ptr(),
+        path.len(),
+        buf.as_mut_ptr(),
+        buf.len(),
+        bufused,
+    )
 }
 
-pub fn wasi_path_rename(
+pub unsafe fn wasi_path_rename(
     old_dirfd: wasi_unstable::Fd,
     old_path: &str,
     new_dirfd: wasi_unstable::Fd,
     new_path: &str,
-) -> wasi_unstable::Errno {
-    unsafe {
-        wasi_unstable::raw::__wasi_path_rename(
-            old_dirfd,
-            old_path.as_ptr() as *const _,
-            old_path.len(),
-            new_dirfd,
-            new_path.as_ptr() as *const _,
-            new_path.len(),
-        )
-    }
+) -> Result<(), wasi_unstable::Error> {
+    wasi_unstable::path_rename(
+        old_dirfd,
+        old_path.as_bytes(),
+        new_dirfd,
+        new_path.as_bytes(),
+    )
 }
 
-pub fn wasi_fd_fdstat_get(
+pub unsafe fn wasi_fd_fdstat_get(
     fd: wasi_unstable::Fd,
     fdstat: &mut wasi_unstable::FdStat,
 ) -> wasi_unstable::Errno {
-    unsafe { wasi_unstable::raw::__wasi_fd_fdstat_get(fd, fdstat) }
+    wasi_unstable::raw::__wasi_fd_fdstat_get(fd, fdstat)
 }
 
-pub fn wasi_fd_seek(
+pub unsafe fn wasi_fd_seek(
     fd: wasi_unstable::Fd,
     offset: wasi_unstable::FileDelta,
     whence: wasi_unstable::Whence,
     newoffset: &mut wasi_unstable::FileSize,
 ) -> wasi_unstable::Errno {
-    unsafe { wasi_unstable::raw::__wasi_fd_seek(fd, offset, whence, newoffset) }
+    wasi_unstable::raw::__wasi_fd_seek(fd, offset, whence, newoffset)
 }
 
-pub fn wasi_fd_tell(
+pub unsafe fn wasi_fd_tell(
     fd: wasi_unstable::Fd,
     offset: &mut wasi_unstable::FileSize,
 ) -> wasi_unstable::Errno {
-    unsafe { wasi_unstable::raw::__wasi_fd_tell(fd, offset) }
+    wasi_unstable::raw::__wasi_fd_tell(fd, offset)
 }
 
-pub fn wasi_clock_time_get(
+pub unsafe fn wasi_clock_time_get(
     clock_id: wasi_unstable::ClockId,
     precision: wasi_unstable::Timestamp,
     time: &mut wasi_unstable::Timestamp,
 ) -> wasi_unstable::Errno {
-    unsafe { wasi_unstable::raw::__wasi_clock_time_get(clock_id, precision, time) }
+    wasi_unstable::raw::__wasi_clock_time_get(clock_id, precision, time)
 }
 
-pub fn wasi_fd_filestat_get(
+pub unsafe fn wasi_fd_filestat_get(
     fd: wasi_unstable::Fd,
     filestat: &mut wasi_unstable::FileStat,
 ) -> wasi_unstable::Errno {
-    unsafe { wasi_unstable::raw::__wasi_fd_filestat_get(fd, filestat) }
+    wasi_unstable::raw::__wasi_fd_filestat_get(fd, filestat)
 }
 
-pub fn wasi_fd_write(
+pub unsafe fn wasi_fd_write(
     fd: wasi_unstable::Fd,
     iovs: &[wasi_unstable::CIoVec],
     nwritten: &mut libc::size_t,
 ) -> wasi_unstable::Errno {
-    unsafe { wasi_unstable::raw::__wasi_fd_write(fd, iovs.as_ptr(), iovs.len(), nwritten) }
+    wasi_unstable::raw::__wasi_fd_write(fd, iovs.as_ptr(), iovs.len(), nwritten)
 }
 
-pub fn wasi_fd_read(
+pub unsafe fn wasi_fd_read(
     fd: wasi_unstable::Fd,
     iovs: &[wasi_unstable::IoVec],
     nread: &mut libc::size_t,
 ) -> wasi_unstable::Errno {
-    unsafe { wasi_unstable::raw::__wasi_fd_read(fd, iovs.as_ptr(), iovs.len(), nread) }
+    wasi_unstable::raw::__wasi_fd_read(fd, iovs.as_ptr(), iovs.len(), nread)
 }
 
-pub fn wasi_fd_pread(
+pub unsafe fn wasi_fd_pread(
     fd: wasi_unstable::Fd,
     iovs: &[wasi_unstable::IoVec],
     offset: wasi_unstable::FileSize,
     nread: &mut usize,
 ) -> wasi_unstable::Errno {
-    unsafe { wasi_unstable::raw::__wasi_fd_pread(fd, iovs.as_ptr(), iovs.len(), offset, nread) }
+    wasi_unstable::raw::__wasi_fd_pread(fd, iovs.as_ptr(), iovs.len(), offset, nread)
 }
 
-pub fn wasi_fd_pwrite(
+pub unsafe fn wasi_fd_pwrite(
     fd: wasi_unstable::Fd,
     iovs: &mut [wasi_unstable::CIoVec],
     offset: wasi_unstable::FileSize,
     nwritten: &mut usize,
 ) -> wasi_unstable::Errno {
-    unsafe { wasi_unstable::raw::__wasi_fd_pwrite(fd, iovs.as_ptr(), iovs.len(), offset, nwritten) }
+    wasi_unstable::raw::__wasi_fd_pwrite(fd, iovs.as_ptr(), iovs.len(), offset, nwritten)
 }
 
-pub fn wasi_path_filestat_get(
-    fd: libc::__wasi_fd_t,
-    dirflags: libc::__wasi_lookupflags_t,
+pub unsafe fn wasi_path_filestat_get(
+    fd: wasi_unstable::Fd,
+    dirflags: wasi_unstable::LookupFlags,
     path: &str,
     path_len: usize,
-    filestat: &mut libc::__wasi_filestat_t,
-) -> libc::__wasi_errno_t {
-    unsafe {
-        libc::__wasi_path_filestat_get(
-            fd,
-            dirflags,
-            path.as_ptr() as *const libc::c_char,
-            path_len,
-            filestat,
-        )
-    }
+    filestat: &mut wasi_unstable::FileStat,
+) -> wasi_unstable::Errno {
+    wasi_unstable::raw::__wasi_path_filestat_get(fd, dirflags, path.as_ptr(), path_len, filestat)
 }
 
-pub fn wasi_path_filestat_set_times(
-    fd: libc::__wasi_fd_t,
-    dirflags: libc::__wasi_lookupflags_t,
+pub unsafe fn wasi_path_filestat_set_times(
+    fd: wasi_unstable::Fd,
+    dirflags: wasi_unstable::LookupFlags,
     path: &str,
-    path_len: usize,
-    st_atim: libc::__wasi_timestamp_t,
-    st_mtim: libc::__wasi_timestamp_t,
-    fst_flags: libc::__wasi_fstflags_t,
-) -> libc::__wasi_errno_t {
-    unsafe {
-        libc::__wasi_path_filestat_set_times(
-            fd,
-            dirflags,
-            path.as_ptr() as *const libc::c_char,
-            path_len,
-            st_atim,
-            st_mtim,
-            fst_flags,
-        )
-    }
+    st_atim: wasi_unstable::Timestamp,
+    st_mtim: wasi_unstable::Timestamp,
+    fst_flags: wasi_unstable::FstFlags,
+) -> Result<(), wasi_unstable::Error> {
+    wasi_unstable::path_filestat_set_times(
+        fd,
+        dirflags,
+        path.as_bytes(),
+        st_atim,
+        st_mtim,
+        fst_flags,
+    )
 }
 
-pub fn wasi_fd_readdir(
+pub unsafe fn wasi_fd_readdir(
     fd: wasi_unstable::Fd,
     buf: &mut [u8],
     buf_len: usize,
     cookie: wasi_unstable::DirCookie,
     buf_used: &mut usize,
 ) -> wasi_unstable::Errno {
-    unsafe {
-        wasi_unstable::raw::__wasi_fd_readdir(
-            fd,
-            buf.as_mut_ptr() as *mut libc::c_void,
-            buf_len,
-            cookie,
-            buf_used,
-        )
-    }
+    wasi_unstable::raw::__wasi_fd_readdir(
+        fd,
+        buf.as_mut_ptr() as *mut libc::c_void,
+        buf_len,
+        cookie,
+        buf_used,
+    )
 }


### PR DESCRIPTION
This switches from using the libc wasi bindings to using the wasi
crate's bindings. This eliminates a git dependency on libc, updates
to the new-style bindings which use Result where possible, and treats
functions that operate on raw file descriptors as unsafe.