### PR TITLE
Add various tests for trailing-slash behavior.

### DIFF
--- a/src/bin/path_rename_trailing_slashes.rs
+++ b/src/bin/path_rename_trailing_slashes.rs
@@ -1,0 +1,68 @@
+use misc_tests::open_scratch_directory;
+use misc_tests::utils::{cleanup_dir, cleanup_file, create_dir, create_file};
+use misc_tests::wasi_wrappers::wasi_path_rename;
+use std::{env, process};
+use wasi::wasi_unstable;
+
+unsafe fn test_path_rename_trailing_slashes(dir_fd: wasi_unstable::Fd) {
+    // Test renaming a file with a trailing slash in the name.
+    create_file(dir_fd, "source");
+    assert_eq!(
+        wasi_path_rename(dir_fd, "source/", dir_fd, "target"),
+        wasi_unstable::raw::__WASI_ENOTDIR,
+        "renaming a file with a trailing slash in the source name"
+    );
+    assert_eq!(
+        wasi_path_rename(dir_fd, "source", dir_fd, "target/"),
+        wasi_unstable::raw::__WASI_ENOTDIR,
+        "renaming a file with a trailing slash in the destination name"
+    );
+    assert_eq!(
+        wasi_path_rename(dir_fd, "source/", dir_fd, "target/"),
+        wasi_unstable::raw::__WASI_ENOTDIR,
+        "renaming a file with a trailing slash in the source and destination names"
+    );
+    cleanup_file(dir_fd, "source");
+
+    // Test renaming a directory with a trailing slash in the name.
+    create_dir(dir_fd, "source");
+    assert_eq!(
+        wasi_path_rename(dir_fd, "source/", dir_fd, "target"),
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "renaming a directory with a trailing slash in the source name"
+    );
+    assert_eq!(
+        wasi_path_rename(dir_fd, "target", dir_fd, "source/"),
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "renaming a directory with a trailing slash in the destination name"
+    );
+    assert_eq!(
+        wasi_path_rename(dir_fd, "source/", dir_fd, "target/"),
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "renaming a directory with a trailing slash in the source and destination names"
+    );
+    cleanup_dir(dir_fd, "target");
+}
+
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    unsafe { test_path_rename_trailing_slashes(dir_fd) }
+}

--- a/src/bin/path_symlink_trailing_slashes.rs
+++ b/src/bin/path_symlink_trailing_slashes.rs
@@ -1,0 +1,81 @@
+use misc_tests::open_scratch_directory;
+use misc_tests::utils::{cleanup_dir, cleanup_file, create_dir, create_file};
+use misc_tests::wasi_wrappers::wasi_path_symlink;
+use std::{env, process};
+use wasi::wasi_unstable;
+
+unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasi_unstable::Fd) {
+    // Link destination shouldn't end with a slash.
+    assert_eq!(
+        wasi_path_symlink("source", dir_fd, "target/"),
+        wasi_unstable::raw::__WASI_ENOENT,
+        "link destination ending with a slash"
+    );
+
+    // Without the trailing slash, this should succeed.
+    assert_eq!(
+        wasi_path_symlink("source", dir_fd, "target"),
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "link destination ending with a slash"
+    );
+    cleanup_file(dir_fd, "target");
+
+    // Link destination already exists, target has trailing slash.
+    create_dir(dir_fd, "target");
+    assert_eq!(
+        wasi_path_symlink("source", dir_fd, "target/"),
+        wasi_unstable::raw::__WASI_EEXIST,
+        "link destination already exists"
+    );
+    cleanup_dir(dir_fd, "target");
+
+    // Link destination already exists, target has no trailing slash.
+    create_dir(dir_fd, "target");
+    assert_eq!(
+        wasi_path_symlink("source", dir_fd, "target"),
+        wasi_unstable::raw::__WASI_EEXIST,
+        "link destination already exists"
+    );
+    cleanup_dir(dir_fd, "target");
+
+    // Link destination already exists, target has trailing slash.
+    create_file(dir_fd, "target");
+    assert_eq!(
+        wasi_path_symlink("source", dir_fd, "target/"),
+        wasi_unstable::raw::__WASI_EEXIST,
+        "link destination already exists"
+    );
+    cleanup_file(dir_fd, "target");
+
+    // Link destination already exists, target has no trailing slash.
+    create_file(dir_fd, "target");
+    assert_eq!(
+        wasi_path_symlink("source", dir_fd, "target"),
+        wasi_unstable::raw::__WASI_EEXIST,
+        "link destination already exists"
+    );
+    cleanup_file(dir_fd, "target");
+}
+
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    unsafe { test_path_symlink_trailing_slashes(dir_fd) }
+}

--- a/src/bin/remove_directory_trailing_slashes.rs
+++ b/src/bin/remove_directory_trailing_slashes.rs
@@ -1,0 +1,68 @@
+use misc_tests::open_scratch_directory;
+use misc_tests::utils::{cleanup_file, create_dir, create_file};
+use misc_tests::wasi_wrappers::wasi_path_remove_directory;
+use std::{env, process};
+use wasi::wasi_unstable;
+
+unsafe fn test_remove_directory_trailing_slashes(dir_fd: wasi_unstable::Fd) {
+    // Create a directory in the scratch directory.
+    create_dir(dir_fd, "dir");
+
+    // Test that removing it succeeds.
+    assert_eq!(
+        wasi_path_remove_directory(dir_fd, "dir"),
+        wasi_unstable::ESUCCESS,
+        "remove_directory on a directory should succeed"
+    );
+
+    create_dir(dir_fd, "dir");
+
+    // Test that removing it with a trailing flash succeeds.
+    assert_eq!(
+        wasi_path_remove_directory(dir_fd, "dir/"),
+        wasi_unstable::ESUCCESS,
+        "remove_directory with a trailing slash on a directory should succeed"
+    );
+
+    // Create a temporary file.
+    create_file(dir_fd, "file");
+
+    // Test that removing it with no trailing flash fails.
+    assert_eq!(
+        wasi_path_remove_directory(dir_fd, "file"),
+        wasi_unstable::ENOTDIR,
+        "remove_directory without a trailing slash on a file should fail"
+    );
+
+    // Test that removing it with a trailing flash fails.
+    assert_eq!(
+        wasi_path_remove_directory(dir_fd, "file/"),
+        wasi_unstable::ENOTDIR,
+        "remove_directory with a trailing slash on a file should fail"
+    );
+
+    cleanup_file(dir_fd, "file");
+}
+
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    unsafe { test_remove_directory_trailing_slashes(dir_fd) }
+}


### PR DESCRIPTION
Three of these tests currently fail under wasi-common but pass under wasi-c: `remove_directory_trailing_slashes`, `path_symlink_trailing_slashes`, and `path_rename_trailing_slashes`.

Thiis may be related to the `needs_final_component` flag of `path_get`, which appears to be true in the wasi-c implementations of some of those system calls.
