### PR TITLE
Add smoke test for fd_advise

### DIFF
--- a/src/bin/fd_advise.rs
+++ b/src/bin/fd_advise.rs
@@ -1,0 +1,96 @@
+use libc;
+use std::{env, process};
+use wasi::wasi_unstable;
+use wasi_misc_tests::open_scratch_directory;
+use wasi_misc_tests::utils::{cleanup_file, close_fd};
+use wasi_misc_tests::wasi_wrappers::{wasi_fd_advise, wasi_fd_filestat_get, wasi_path_open};
+
+unsafe fn test_fd_advise(dir_fd: wasi_unstable::Fd) {
+    // Create a file in the scratch directory.
+    let mut file_fd = wasi_unstable::Fd::max_value() - 1;
+    let status = wasi_path_open(
+        dir_fd,
+        0,
+        "file",
+        wasi_unstable::O_CREAT,
+        wasi_unstable::RIGHT_FD_READ | wasi_unstable::RIGHT_FD_WRITE,
+        0,
+        0,
+        &mut file_fd,
+    );
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "opening a file"
+    );
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+        "file descriptor range check",
+    );
+
+    // Check file size
+    let mut stat = wasi_unstable::FileStat {
+        st_dev: 0,
+        st_ino: 0,
+        st_filetype: 0,
+        st_nlink: 0,
+        st_size: 0,
+        st_atim: 0,
+        st_mtim: 0,
+        st_ctim: 0,
+    };
+    let status = wasi_fd_filestat_get(file_fd, &mut stat);
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "reading file stats"
+    );
+    assert_eq!(stat.st_size, 0, "file size should be 0");
+
+    // Allocate some size
+    assert!(
+        wasi_unstable::fd_allocate(file_fd, 0, 100).is_ok(),
+        "allocating size"
+    );
+
+    let status = wasi_fd_filestat_get(file_fd, &mut stat);
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "reading file stats after initial allocation"
+    );
+    assert_eq!(stat.st_size, 100, "file size should be 100");
+
+    // Advise the kernel
+    let status = wasi_fd_advise(file_fd, 10, 50, wasi_unstable::ADVICE_NORMAL);
+    assert_eq!(
+        status,
+        wasi_unstable::raw::__WASI_ESUCCESS,
+        "advising the kernel"
+    );
+
+    close_fd(file_fd);
+    cleanup_file(dir_fd, "file");
+}
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    unsafe { test_fd_advise(dir_fd) }
+}

--- a/src/wasi_wrappers.rs
+++ b/src/wasi_wrappers.rs
@@ -206,3 +206,12 @@ pub unsafe fn wasi_fd_readdir(
         buf_used,
     )
 }
+
+pub unsafe fn wasi_fd_advise(
+    fd: wasi_unstable::Fd,
+    offset: wasi_unstable::FileSize,
+    len: wasi_unstable::FileSize,
+    advice: wasi_unstable::Advice,
+) -> wasi_unstable::Errno {
+    wasi_unstable::raw::__wasi_fd_advise(fd, offset, len, advice)
+}


### PR DESCRIPTION
This test is a true smoke test as it only tests whether issuing
an advise call to the host's kernel doesn't yield an error. The
consequence of issuing such a syscall is not tested.