### PR TITLE
Refactor the (in)equality assertions for more debuggable errors.

### DIFF
--- a/src/bin/close_preopen.rs
+++ b/src/bin/close_preopen.rs
@@ -3,11 +3,12 @@ use std::{env, mem, process};
 use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::wasi_wrappers::wasi_fd_fdstat_get;
+use more_asserts::assert_gt;
 
 unsafe fn test_close_preopen(dir_fd: wasi_unstable::Fd) {
     let pre_fd: wasi_unstable::Fd = (libc::STDERR_FILENO + 1) as wasi_unstable::Fd;
 
-    assert!(dir_fd > pre_fd, "dir_fd number");
+    assert_gt!(dir_fd, pre_fd, "dir_fd number");
 
     // Try to close a preopened directory handle.
     assert_eq!(
@@ -31,8 +32,8 @@ unsafe fn test_close_preopen(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "calling fd_fdstat on the scratch directory"
     );
-    assert!(
-        dir_fdstat.fs_filetype == wasi_unstable::FILETYPE_DIRECTORY,
+    assert_eq!(
+        dir_fdstat.fs_filetype, wasi_unstable::FILETYPE_DIRECTORY,
         "expected the scratch directory to be a directory",
     );
 
@@ -50,8 +51,8 @@ unsafe fn test_close_preopen(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "calling fd_fdstat on the scratch directory"
     );
-    assert!(
-        dir_fdstat.fs_filetype == wasi_unstable::FILETYPE_DIRECTORY,
+    assert_eq!(
+        dir_fdstat.fs_filetype, wasi_unstable::FILETYPE_DIRECTORY,
         "expected the scratch directory to be a directory",
     );
 }

--- a/src/bin/directory_seek.rs
+++ b/src/bin/directory_seek.rs
@@ -4,6 +4,7 @@ use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_dir, close_fd, create_dir};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_fdstat_get, wasi_fd_seek, wasi_path_open};
+use more_asserts::assert_gt;
 
 unsafe fn test_directory_seek(dir_fd: wasi_unstable::Fd) {
     // Create a directory in the scratch directory.
@@ -26,8 +27,8 @@ unsafe fn test_directory_seek(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 
@@ -48,8 +49,8 @@ unsafe fn test_directory_seek(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "calling fd_fdstat on a directory"
     );
-    assert!(
-        fdstat.fs_filetype == wasi_unstable::FILETYPE_DIRECTORY,
+    assert_eq!(
+        fdstat.fs_filetype, wasi_unstable::FILETYPE_DIRECTORY,
         "expected the scratch directory to be a directory",
     );
     assert_eq!(

--- a/src/bin/fd_advise.rs
+++ b/src/bin/fd_advise.rs
@@ -4,6 +4,7 @@ use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_advise, wasi_fd_filestat_get, wasi_path_open};
+use more_asserts::assert_gt;
 
 unsafe fn test_fd_advise(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory.
@@ -23,8 +24,8 @@ unsafe fn test_fd_advise(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 

--- a/src/bin/fd_filestat_set.rs
+++ b/src/bin/fd_filestat_set.rs
@@ -4,6 +4,7 @@ use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_filestat_get, wasi_path_open};
+use more_asserts::assert_gt;
 
 unsafe fn test_fd_filestat_set(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory.
@@ -23,8 +24,8 @@ unsafe fn test_fd_filestat_set(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 

--- a/src/bin/fd_readdir.rs
+++ b/src/bin/fd_readdir.rs
@@ -3,6 +3,7 @@ use std::{cmp::min, env, mem, process, slice, str};
 use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_filestat_get, wasi_fd_readdir, wasi_path_open};
+use more_asserts::assert_gt;
 
 const BUF_LEN: usize = 256;
 
@@ -122,8 +123,8 @@ unsafe fn test_fd_readdir(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 

--- a/src/bin/file_allocate.rs
+++ b/src/bin/file_allocate.rs
@@ -4,6 +4,7 @@ use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_filestat_get, wasi_path_open};
+use more_asserts::assert_gt;
 
 unsafe fn test_file_allocate(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory.
@@ -23,8 +24,8 @@ unsafe fn test_file_allocate(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 

--- a/src/bin/file_pread_pwrite.rs
+++ b/src/bin/file_pread_pwrite.rs
@@ -4,6 +4,7 @@ use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_pread, wasi_fd_pwrite, wasi_path_open};
+use more_asserts::assert_gt;
 
 unsafe fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory.
@@ -23,8 +24,8 @@ unsafe fn test_file_pread_pwrite(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 

--- a/src/bin/file_seek_tell.rs
+++ b/src/bin/file_seek_tell.rs
@@ -4,6 +4,7 @@ use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_seek, wasi_fd_tell, wasi_fd_write, wasi_path_open};
+use more_asserts::assert_gt;
 
 unsafe fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory.
@@ -23,8 +24,8 @@ unsafe fn test_file_seek_tell(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 

--- a/src/bin/file_unbuffered_write.rs
+++ b/src/bin/file_unbuffered_write.rs
@@ -4,6 +4,7 @@ use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd, create_file};
 use wasi_misc_tests::wasi_wrappers::{wasi_fd_read, wasi_fd_write, wasi_path_open};
+use more_asserts::assert_gt;
 
 unsafe fn test_file_unbuffered_write(dir_fd: wasi_unstable::Fd) {
     // Create file
@@ -26,8 +27,8 @@ unsafe fn test_file_unbuffered_write(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        fd_read > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        fd_read, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 
@@ -48,8 +49,8 @@ unsafe fn test_file_unbuffered_write(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        fd_write > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        fd_write, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 

--- a/src/bin/interesting_paths.rs
+++ b/src/bin/interesting_paths.rs
@@ -6,6 +6,7 @@ use wasi_misc_tests::utils::{close_fd, create_dir, create_file};
 use wasi_misc_tests::wasi_wrappers::{
     wasi_path_open, wasi_path_remove_directory, wasi_path_unlink_file,
 };
+use more_asserts::assert_gt;
 
 unsafe fn test_interesting_paths(dir_fd: wasi_unstable::Fd, arg: &str) {
     // Create a directory in the scratch directory.
@@ -47,8 +48,8 @@ unsafe fn test_interesting_paths(dir_fd: wasi_unstable::Fd, arg: &str) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file with \"..\" in the path"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
     close_fd(file_fd);
@@ -99,8 +100,8 @@ unsafe fn test_interesting_paths(dir_fd: wasi_unstable::Fd, arg: &str) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a directory with a trailing slash"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
     close_fd(file_fd);
@@ -112,8 +113,8 @@ unsafe fn test_interesting_paths(dir_fd: wasi_unstable::Fd, arg: &str) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a directory with trailing slashes"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
     close_fd(file_fd);

--- a/src/bin/isatty.rs
+++ b/src/bin/isatty.rs
@@ -4,6 +4,7 @@ use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
 use wasi_misc_tests::utils::{cleanup_file, close_fd};
 use wasi_misc_tests::wasi_wrappers::wasi_path_open;
+use more_asserts::assert_gt;
 
 unsafe fn test_isatty(dir_fd: wasi_unstable::Fd) {
     // Create a file in the scratch directory and test if it's a tty.
@@ -23,8 +24,8 @@ unsafe fn test_isatty(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd, libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
     assert_eq!(

--- a/src/bin/nofollow_errors.rs
+++ b/src/bin/nofollow_errors.rs
@@ -1,4 +1,5 @@
 use libc;
+use more_asserts::assert_gt;
 use std::{env, process};
 use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
@@ -69,8 +70,9 @@ unsafe fn test_nofollow_errors(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a symlink as a directory"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd,
+        libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
     close_fd(file_fd);

--- a/src/bin/path_filestat.rs
+++ b/src/bin/path_filestat.rs
@@ -1,4 +1,5 @@
 use libc;
+use more_asserts::assert_gt;
 use std::{env, process};
 use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
@@ -12,12 +13,14 @@ unsafe fn test_path_filestat(dir_fd: wasi_unstable::Fd) {
     let status = wasi_fd_fdstat_get(dir_fd, &mut fdstat);
     assert_eq!(status, wasi_unstable::raw::__WASI_ESUCCESS, "fd_fdstat_get");
 
-    assert!(
-        (fdstat.fs_rights_base & wasi_unstable::RIGHT_PATH_FILESTAT_GET) != 0,
+    assert_ne!(
+        fdstat.fs_rights_base & wasi_unstable::RIGHT_PATH_FILESTAT_GET,
+        0,
         "the scratch directory should have RIGHT_PATH_FILESTAT_GET as base right",
     );
-    assert!(
-        (fdstat.fs_rights_inheriting & wasi_unstable::RIGHT_PATH_FILESTAT_GET) != 0,
+    assert_ne!(
+        fdstat.fs_rights_inheriting & wasi_unstable::RIGHT_PATH_FILESTAT_GET,
+        0,
         "the scratch directory should have RIGHT_PATH_FILESTAT_GET as base right",
     );
 
@@ -41,8 +44,9 @@ unsafe fn test_path_filestat(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd,
+        libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 

--- a/src/bin/path_rename.rs
+++ b/src/bin/path_rename.rs
@@ -1,4 +1,5 @@
 use libc;
+use more_asserts::assert_gt;
 use std::{env, process};
 use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
@@ -55,8 +56,9 @@ unsafe fn test_path_rename(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening renamed path as a directory"
     );
-    assert!(
-        fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        fd,
+        libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 
@@ -111,8 +113,9 @@ unsafe fn test_path_rename(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening renamed path as a directory"
     );
-    assert!(
-        fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        fd,
+        libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 
@@ -170,8 +173,9 @@ unsafe fn test_path_rename(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening renamed path"
     );
-    assert!(
-        fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        fd,
+        libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 
@@ -208,8 +212,9 @@ unsafe fn test_path_rename(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening renamed path"
     );
-    assert!(
-        fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        fd,
+        libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 

--- a/src/bin/renumber.rs
+++ b/src/bin/renumber.rs
@@ -1,4 +1,5 @@
 use libc;
+use more_asserts::assert_gt;
 use std::{env, mem, process};
 use wasi::wasi_unstable;
 use wasi_misc_tests::open_scratch_directory;
@@ -8,7 +9,7 @@ use wasi_misc_tests::wasi_wrappers::{wasi_fd_fdstat_get, wasi_path_open};
 unsafe fn test_renumber(dir_fd: wasi_unstable::Fd) {
     let pre_fd: wasi_unstable::Fd = (libc::STDERR_FILENO + 1) as wasi_unstable::Fd;
 
-    assert!(dir_fd > pre_fd, "dir_fd number");
+    assert_gt!(dir_fd, pre_fd, "dir_fd number");
 
     // Create a file in the scratch directory.
     let mut fd_from = wasi_unstable::Fd::max_value() - 1;
@@ -27,8 +28,9 @@ unsafe fn test_renumber(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        fd_from > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        fd_from,
+        libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 
@@ -58,8 +60,9 @@ unsafe fn test_renumber(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "opening a file"
     );
-    assert!(
-        fd_to > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        fd_to,
+        libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
 
@@ -84,12 +87,21 @@ unsafe fn test_renumber(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "calling fd_fdstat on the open file descriptor"
     );
-    assert!(
-        fdstat_from.fs_filetype == fdstat_to.fs_filetype
-            && fdstat_from.fs_flags == fdstat_to.fs_flags
-            && fdstat_from.fs_rights_base == fdstat_to.fs_rights_base
-            && fdstat_from.fs_rights_inheriting == fdstat_to.fs_rights_inheriting,
-        "expected fd_to have the same fdstat as fd_from",
+    assert_eq!(
+        fdstat_from.fs_filetype, fdstat_to.fs_filetype,
+        "expected fd_to have the same fdstat as fd_from"
+    );
+    assert_eq!(
+        fdstat_from.fs_flags, fdstat_to.fs_flags,
+        "expected fd_to have the same fdstat as fd_from"
+    );
+    assert_eq!(
+        fdstat_from.fs_rights_base, fdstat_to.fs_rights_base,
+        "expected fd_to have the same fdstat as fd_from"
+    );
+    assert_eq!(
+        fdstat_from.fs_rights_inheriting, fdstat_to.fs_rights_inheriting,
+        "expected fd_to have the same fdstat as fd_from"
     );
 
     close_fd(fd_to);

--- a/src/bin/truncation_rights.rs
+++ b/src/bin/truncation_rights.rs
@@ -16,16 +16,18 @@ unsafe fn test_truncation_rights(dir_fd: wasi_unstable::Fd) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "calling fd_fdstat on the scratch directory"
     );
-    assert!(
-        dir_fdstat.fs_filetype == wasi_unstable::FILETYPE_DIRECTORY,
+    assert_eq!(
+        dir_fdstat.fs_filetype,
+        wasi_unstable::FILETYPE_DIRECTORY,
         "expected the scratch directory to be a directory",
     );
-    assert!(
-        dir_fdstat.fs_flags == 0,
+    assert_eq!(
+        dir_fdstat.fs_flags, 0,
         "expected the scratch directory to have no special flags",
     );
-    assert!(
-        (dir_fdstat.fs_rights_base & wasi_unstable::RIGHT_FD_FILESTAT_SET_SIZE) == 0,
+    assert_eq!(
+        dir_fdstat.fs_rights_base & wasi_unstable::RIGHT_FD_FILESTAT_SET_SIZE,
+        0,
         "directories shouldn't have the fd_filestat_set_size right",
     );
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,8 +33,9 @@ pub unsafe fn create_file(dir_fd: wasi_unstable::Fd, file_name: &str) {
         wasi_unstable::raw::__WASI_ESUCCESS,
         "creating a file"
     );
-    assert!(
-        file_fd > libc::STDERR_FILENO as wasi_unstable::Fd,
+    assert_gt!(
+        file_fd,
+        libc::STDERR_FILENO as wasi_unstable::Fd,
         "file descriptor range check",
     );
     close_fd(file_fd);


### PR DESCRIPTION
Assertions in `truncation_rights.rs` are a pain to debug, so I changed all (in)equalities to use specialized assertions for more meaningful error messages.